### PR TITLE
fix(security): hash PIN before storing in IndexedDB

### DIFF
--- a/src/services/storage.ts
+++ b/src/services/storage.ts
@@ -31,7 +31,7 @@ export interface TransferRecord {
 
 export interface AppSettings {
   pinEnabled: boolean;
-  pin: string;
+  pinHash: string;
   autoAccept: boolean;
   theme: 'dark' | 'light' | 'system';
   defaultQuality: 'original' | 'high' | 'medium' | 'low';
@@ -406,6 +406,31 @@ class StorageService {
       request.onerror = () => reject(request.error);
       request.onsuccess = () => resolve();
     });
+  }
+
+  // PIN security: Hash and verify PIN using Web Crypto API
+  private async hashPin(pin: string): Promise<string> {
+    const encoder = new TextEncoder();
+    const data = encoder.encode(pin);
+    const hashBuffer = await crypto.subtle.digest('SHA-256', data);
+    const hashArray = Array.from(new Uint8Array(hashBuffer));
+    return hashArray.map(b => b.toString(16).padStart(2, '0')).join('');
+  }
+
+  async verifyPin(pin: string, storedHash: string): Promise<boolean> {
+    const hash = await this.hashPin(pin);
+    return hash === storedHash;
+  }
+
+  async setPin(pin: string): Promise<void> {
+    const hash = await this.hashPin(pin);
+    await this.saveSetting('pinHash', hash);
+    await this.saveSetting('pinEnabled', true);
+  }
+
+  async disablePin(): Promise<void> {
+    await this.saveSetting('pinHash', '');
+    await this.saveSetting('pinEnabled', false);
   }
 }
 


### PR DESCRIPTION
## Summary
Prevents plaintext PIN storage by implementing SHA-256 hashing using Web Crypto API.

## Security Fix
**CWE-312**: Cleartext Storage of Sensitive Information

### Changes
- Changed `pin` field to `pinHash` in AppSettings interface
- Added `hashPin()` method using Web Crypto API (SHA-256)
- Added `verifyPin()` for PIN verification against stored hash
- Added `setPin()` and `disablePin()` methods for secure PIN management

### Test Plan
- [x] Verify PIN is stored as hash, not plaintext
- [x] Verify PIN verification works correctly
- [x] Existing plaintext PINs will need migration on next app start