### PR TITLE
fix(CI): Fix remaining TypeScript errors

### DIFF
--- a/src/services/enhanced-webrtc.ts
+++ b/src/services/enhanced-webrtc.ts
@@ -18,7 +18,6 @@ interface QueuedTransfer {
   deviceId: string;
   priority: number;
   retryCount: number;
-  maxRetries: number;
   fileId?: string;
   relativePath?: string;
 }
@@ -237,7 +236,7 @@ class EnhancedWebRTC {
     try {
       if (data instanceof ArrayBuffer) await this.handleBinaryChunk(data, deviceId);
       else if (typeof data === 'string') { const message = JSON.parse(data); await this.handleControlMessage(message, deviceId); }
-    } catch { console.error('Error handling data message:', error); }
+    } catch (e) { console.error('Error handling data message:', e); }
   }
 
   private async handleControlMessage(message: { type: string; [key: string]: unknown }, deviceId: string) {

--- a/src/utils/errors.ts
+++ b/src/utils/errors.ts
@@ -1,6 +1,7 @@
 export type TransferErrorCode =
   | 'FILE_TOO_LARGE'
   | 'NOT_CONNECTED'
+  | 'CONNECTION_CLOSED'
   | 'TRANSFER_FAILED'
   | 'VERIFICATION_FAILED'
   | 'INVALID_FILE'


### PR DESCRIPTION
## Summary
This PR fixes the remaining CI TypeScript/lint errors:

### Changes
1. **enhanced-webrtc.ts**: Removed `maxRetries` from `QueuedTransfer` interface (unused property causing type mismatch)
2. **enhanced-webrtc.ts**: Fixed catch block error - changed bare `catch` with `error` reference to `catch (e)`
3. **errors.ts**: Added `CONNECTION_CLOSED` to `TransferErrorCode` type

### Errors Fixed
- L411: `CONNECTION_CLOSED` not assignable to TransferErrorCode
- L240: Cannot find name `error`
- L132: Object type mismatch in queueTransfer

### Testing
CI should now pass all checks.